### PR TITLE
Fix 1337x poster URL

### DIFF
--- a/torrent/1337x.js
+++ b/torrent/1337x.js
@@ -36,10 +36,15 @@ async function torrent1337x(query = '', page = '1') {
         const $ = cheerio.load(html.data);
         data.Name = $('.box-info-heading h1').text().trim();
         data.Magnet = $('.clearfix ul li a').attr('href') || "";
-        const poster = ("https:" + $('div.torrent-image img').attr('src'));
+        const poster = $('div.torrent-image img').attr('src');
         
-        if (poster !== 'https:undefined') {
-            data.Poster = poster
+        if (typeof poster !== 'undefined') {
+            if (poster.startsWith('http')){
+                data.Poster = poster;
+            }
+            else{
+                data.Poster = 'https:' + poster;
+            }
         } else {
             data.Poster = ''
         }


### PR DESCRIPTION
In some of the domains of 1337x, the poster URL already starts with `https:`. so, adding `https:` if required only.

Before (**Invalid**):
`"Poster": "https:https://lx1.dyncdn.cc/cdn/83/83d607a6e927e9a6f04d7ec8849f21a3.jpg"`

After:
`"Poster": "https://lx1.dyncdn.cc/cdn/83/83d607a6e927e9a6f04d7ec8849f21a3.jpg"`

Thanks for the API, great work :)